### PR TITLE
Fix rc-local.service install error

### DIFF
--- a/System/install.sh
+++ b/System/install.sh
@@ -6,5 +6,5 @@ sudo apt-get remove -y ubuntu-release-upgrader-core
 sudo chmod 440 sudoers
 sudo cp sudoers  /etc/
 sudo cp rc.local /etc/
-sudo cp rc.local.service /lib/systemd/system/
+sudo cp rc-local.service /lib/systemd/system/
 sudo systemctl enable rc-local

--- a/System/rc-local.service
+++ b/System/rc-local.service
@@ -24,5 +24,4 @@ GuessMainPID=no
 
 [Install]
 WantedBy=multi-user.target
-Alias=rc-local.service
-
+Alias=rc.local.service


### PR DESCRIPTION
This PR fixes the rc-local.service install error.
ref: https://github.com/mangdangroboticsclub/minipupper_ros_bsp/pull/2

The current install script shows the following output while installing.

```
++ sudo systemctl enable rc-local
The unit files have no installation config (WantedBy=, RequiredBy=, Also=,
Alias= settings in the [Install] section, and DefaultInstance= for template
units). This means they are not meant to be enabled using systemctl.
 
Possible reasons for having this kind of units are:
• A unit may be statically enabled by being symlinked from another unit's
  .wants/ or .requires/ directory.
• A unit's purpose may be to act as a helper for some other unit which has
  a requirement dependency on it.
• A unit may be started when needed via activation (socket, path, timer,
  D-Bus, udev, scripted systemctl call, ...).
• In case of template units, the unit is meant to be enabled with some
  instance name specified.
```
![2022-04-17-023700](https://user-images.githubusercontent.com/3256629/163685889-dd446835-3b63-48b2-aaac-4d5023b6fd2e.jpg)

