### PR TITLE
Fix python_module install error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -55,10 +55,9 @@ sudo sed -i "s|BASEDIR|$BASEDIR|" /etc/rc.local
 sudo sed -i "s|BASEDIR|$BASEDIR|" /usr/bin/battery_monitor
 
 ### Install pip
-cd /tmp
-wget --no-check-certificate https://bootstrap.pypa.io/get-pip.py
-sudo python get-pip.py
+sudo apt install -y python3-pip python3-dev
+sudo -H python3 -m pip install --upgrade pip
 
 ### Install LCD driver
-sudo apt install -y python3-dev
-sudo pip install $BASEDIR/python_module
+sudo git config --global add safe.directory $BASEDIR # temporary fix https://bugs.launchpad.net/devstack/+bug/1968798
+sudo -H python3 -m pip install $BASEDIR/python_module


### PR DESCRIPTION
This PR fixes [python_module](https://github.com/hdumcke/minipupper_base/tree/main/python_module) install error.
ref: https://bugs.launchpad.net/devstack/+bug/1968798

The current install script shows the following output while installing.


```
Processing /home/ubuntu/minipupper_base/python_module
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [22 lines of output]
      /usr/local/lib/python3.8/dist-packages/setuptools/dist.py:757: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
        warnings.warn(
      /usr/local/lib/python3.8/dist-packages/setuptools/dist.py:757: UserWarning: Usage of dash-separated 'author-email' will not be supported in future versions. Please use the underscore name 'author_email' instead
        warnings.warn(
      /usr/local/lib/python3.8/dist-packages/setuptools/dist.py:757: UserWarning: Usage of dash-separated 'home-page' will not be supported in future versions. Please use the underscore name 'home_page' instead
        warnings.warn(
      Error parsing
      Traceback (most recent call last):
        File "/usr/lib/python3/dist-packages/pbr/core.py", line 96, in pbr
          attrs = util.cfg_to_args(path, dist.script_args)
        File "/usr/lib/python3/dist-packages/pbr/util.py", line 271, in cfg_to_args
          pbr.hooks.setup_hook(config)
        File "/usr/lib/python3/dist-packages/pbr/hooks/__init__.py", line 25, in setup_hook
          metadata_config.run()
        File "/usr/lib/python3/dist-packages/pbr/hooks/base.py", line 27, in run
          self.hook()
        File "/usr/lib/python3/dist-packages/pbr/hooks/metadata.py", line 25, in hook
          self.config['version'] = packaging.get_version(
        File "/usr/lib/python3/dist-packages/pbr/packaging.py", line 870, in get_version
          raise Exception("Versioning for this project requires either an sdist"
      Exception: Versioning for this project requires either an sdist tarball, or access to an upstream git repository. It's also possible that there is a mismatch between the package name in setup.cfg and the argument given to pbr.version.VersionInfo. Project name Mangdang was given, but was not able to be found.
      error in setup command: Error parsing /home/ubuntu/minipupper_base/python_module/setup.cfg: Exception: Versioning for this project requires either an sdist tarball, or access to an upstream git repository. It's also possible that there is a mismatch between the package name in setup.cfg and the argument given to pbr.version.VersionInfo. Project name Mangdang was given, but was not able to be found.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.

```

![2022-04-17-023427](https://user-images.githubusercontent.com/3256629/163687702-41a415dc-1635-4102-8cea-a7823e0f3c66.jpg)
